### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: SonarQube
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/djleamen/daily-journal/security/code-scanning/1](https://github.com/djleamen/daily-journal/security/code-scanning/1)

The best way to fix the problem is to explicitly add a `permissions` block to limit the GITHUB_TOKEN's permissions for this workflow, following the principle of least privilege. Since the job actions (checkout, caching, build, and analysis) only require read access to repository contents (and access to provided secrets), setting `permissions: contents: read` is sufficient. This can be added at the root level of the workflow YAML (for all jobs), or just before the `build` job if job-specific permissions are desired. Adding it at the root is clearer and covers future jobs by default.

To implement the change:
- Add the following block below the workflow `name:` (after line 1):
  ```
  permissions:
    contents: read
  ```
  If, in the future, a job or step requires additional or different permissions, those can be explicitly set at the job level.

No further code or file changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
