### PR TITLE
fix(auth): use salted PBKDF2 for unlock-password hashing

### DIFF
--- a/src/java/main/PasswordManager.java
+++ b/src/java/main/PasswordManager.java
@@ -2,17 +2,44 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.util.Base64;
 import java.util.logging.Logger;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.PBEKeySpec;
 
 /**
- * The {@code PasswordManager} class is a utility class for managing 
- * password storage and verification. Passwords are hashed using SHA-256 
- * and stored in a JSON file.
+ * The {@code PasswordManager} class is a utility class for managing
+ * password storage and verification. Passwords are stretched with a salted,
+ * deliberately-slow key derivation function (PBKDF2 with HMAC-SHA256) and the
+ * salt, iteration count, and derived hash are stored together in a JSON file.
+ *
+ * <p>Older installs that stored a single, unsalted SHA-256 hex digest under
+ * {@code passwordHash} are still accepted: such a legacy password verifies
+ * once against the old scheme and is then transparently re-hashed and rewritten
+ * in the salted format, so existing users are not locked out.
  */
 public class PasswordManager {
     private static final Logger logger = Logger.getLogger(PasswordManager.class.getName());
+
+    /** Key derivation function used for newly stored passwords. */
+    private static final String KDF_ALGORITHM = "PBKDF2WithHmacSHA256";
+    /** Work factor for the KDF; high enough to make brute force expensive. */
+    private static final int ITERATIONS = 210_000;
+    /** Length of the per-password random salt, in bytes. */
+    private static final int SALT_LENGTH = 16;
+    /** Length of the derived hash, in bits. */
+    private static final int KEY_LENGTH = 256;
+    private static final SecureRandom RANDOM = new SecureRandom();
+
     private final String filePath;
-    private String storedHash;
+    // Salted-KDF credential; null when no password is set or only a legacy hash was loaded.
+    private byte[] salt;
+    private int iterations;
+    private byte[] hash;
+    // Legacy bare SHA-256 hex digest; null unless an old-format password.json was loaded.
+    private String legacyHash;
 
     /**
      * Constructs a {@code PasswordManager} with the specified file path.
@@ -26,13 +53,14 @@ public class PasswordManager {
     }
 
     /**
-     * Loads the stored password hash from the file.
-     * If the file does not exist, the stored hash is set to {@code null}.
+     * Loads the stored credential from the file. Both the salted-KDF format
+     * ({@code salt}/{@code iterations}/{@code hash}) and the legacy bare-hex
+     * format ({@code passwordHash}) are recognised. If the file does not exist
+     * no credential is loaded.
      */
     private void loadPassword() {
         File file = new File(filePath);
         if (!file.exists()) {
-            storedHash = null;
             return;
         }
         try (BufferedReader reader = new BufferedReader(new FileReader(file))) {
@@ -42,7 +70,15 @@ public class PasswordManager {
                 jsonStr.append(line);
             }
             JSONObject json = new JSONObject(jsonStr.toString());
-            storedHash = json.getString("passwordHash");
+            String encodedHash = json.getString("hash");
+            if (encodedHash != null) {
+                this.salt = Base64.getDecoder().decode(json.getString("salt"));
+                this.iterations = Integer.parseInt(json.getString("iterations"));
+                this.hash = Base64.getDecoder().decode(encodedHash);
+            } else {
+                // Fall back to the legacy unsalted SHA-256 digest, if present.
+                this.legacyHash = json.getString("passwordHash");
+            }
         } catch (Exception e) {
             logger.severe(String.format("Error loading password from file: %s - %s", filePath, e.getMessage()));
         }
@@ -54,28 +90,56 @@ public class PasswordManager {
      * @return {@code true} if a password is set, {@code false} otherwise
      */
     public boolean isPasswordSet() {
-        return storedHash != null;
+        return hash != null || legacyHash != null;
     }
 
     /**
-     * Verifies if the provided password matches the stored password hash.
+     * Verifies if the provided password matches the stored credential, using a
+     * constant-time comparison. A password stored in the legacy unsalted format
+     * that verifies successfully is transparently upgraded to the salted-KDF
+     * format and rewritten to disk.
      *
      * @param password the password to verify
      * @return {@code true} if the password matches, {@code false} otherwise
      */
     public boolean verifyPassword(String password) {
-        return hashPassword(password).equals(storedHash);
+        if (hash != null) {
+            byte[] candidate = pbkdf2(password, salt, iterations, hash.length * 8);
+            return MessageDigest.isEqual(candidate, hash);
+        }
+        if (legacyHash != null) {
+            boolean matches = MessageDigest.isEqual(
+                    legacyHash.getBytes(StandardCharsets.UTF_8),
+                    legacySha256Hex(password).getBytes(StandardCharsets.UTF_8));
+            if (matches) {
+                // Migrate the verified legacy password to the salted-KDF format.
+                setPassword(password);
+            }
+            return matches;
+        }
+        return false;
     }
 
     /**
-     * Sets a new password by hashing it and storing the hash in the file.
+     * Sets a new password by deriving a salted hash and storing the salt,
+     * iteration count, and hash in the file.
      *
      * @param password the new password to set
      */
     public void setPassword(String password) {
-        storedHash = hashPassword(password);
+        byte[] newSalt = new byte[SALT_LENGTH];
+        RANDOM.nextBytes(newSalt);
+        byte[] newHash = pbkdf2(password, newSalt, ITERATIONS, KEY_LENGTH);
+        this.salt = newSalt;
+        this.iterations = ITERATIONS;
+        this.hash = newHash;
+        this.legacyHash = null;
+
         JSONObject json = new JSONObject();
-        json.put("passwordHash", storedHash);
+        json.put("algo", KDF_ALGORITHM);
+        json.put("salt", Base64.getEncoder().encodeToString(newSalt));
+        json.put("iterations", ITERATIONS);
+        json.put("hash", Base64.getEncoder().encodeToString(newHash));
         try (PrintWriter writer = new PrintWriter(new FileWriter(filePath))) {
             writer.write(json.toString(4));
         } catch (Exception e) {
@@ -84,13 +148,37 @@ public class PasswordManager {
     }
 
     /**
-     * Hashes the provided password using SHA-256.
+     * Derives a hash from the password using PBKDF2 with HMAC-SHA256.
+     *
+     * @param password      the password to stretch
+     * @param salt          the per-password salt
+     * @param iterations    the KDF work factor
+     * @param keyLengthBits the desired hash length, in bits
+     * @return the derived hash bytes
+     * @throws PasswordHashingException if the derivation fails
+     */
+    private static byte[] pbkdf2(String password, byte[] salt, int iterations, int keyLengthBits) {
+        PBEKeySpec spec = new PBEKeySpec(password.toCharArray(), salt, iterations, keyLengthBits);
+        try {
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(KDF_ALGORITHM);
+            return factory.generateSecret(spec).getEncoded();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException ex) {
+            throw new PasswordHashingException("Failed to hash password: " + KDF_ALGORITHM + " not available", ex);
+        } finally {
+            spec.clearPassword();
+        }
+    }
+
+    /**
+     * Hashes the provided password using the legacy unsalted SHA-256 scheme.
+     * Retained only to verify (and then upgrade) passwords stored before the
+     * migration to a salted KDF.
      *
      * @param password the password to hash
      * @return the hashed password as a hexadecimal string
      * @throws PasswordHashingException if the hashing process fails
      */
-    public static String hashPassword(String password) {
+    private static String legacySha256Hex(String password) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));

--- a/src/java/test/PasswordManagerTest.java
+++ b/src/java/test/PasswordManagerTest.java
@@ -1,20 +1,15 @@
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.security.MessageDigest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 class PasswordManagerTest {
-
-    @Test
-    void hashIsDeterministicAndNonEmpty() {
-        String hash1 = PasswordManager.hashPassword("secret");
-        String hash2 = PasswordManager.hashPassword("secret");
-        assertEquals(hash1, hash2);
-        assertEquals(64, hash1.length()); // SHA-256 hex
-        assertNotEquals(hash1, PasswordManager.hashPassword("other"));
-    }
 
     @Test
     void newManagerHasNoPassword(@TempDir Path tempDir) {
@@ -42,5 +37,75 @@ class PasswordManagerTest {
         PasswordManager reloaded = new PasswordManager(file.getAbsolutePath());
         assertTrue(reloaded.isPasswordSet());
         assertTrue(reloaded.verifyPassword("pw"));
+    }
+
+    @Test
+    void storedFormatIsSaltedKdfNotBareSha256(@TempDir Path tempDir) throws Exception {
+        File file = tempDir.resolve("password.json").toFile();
+        new PasswordManager(file.getAbsolutePath()).setPassword("secret");
+
+        String stored = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        assertTrue(stored.contains("salt"));
+        assertTrue(stored.contains("iterations"));
+        assertTrue(stored.contains("hash"));
+        // The bare unsalted SHA-256 digest must never be written.
+        assertFalse(stored.contains("passwordHash"));
+        assertFalse(stored.contains(sha256Hex("secret")));
+    }
+
+    @Test
+    void saltMakesIdenticalPasswordsStoreDifferently(@TempDir Path tempDir) throws Exception {
+        File fileA = tempDir.resolve("a.json").toFile();
+        File fileB = tempDir.resolve("b.json").toFile();
+        new PasswordManager(fileA.getAbsolutePath()).setPassword("samepass");
+        new PasswordManager(fileB.getAbsolutePath()).setPassword("samepass");
+
+        String storedA = new String(Files.readAllBytes(fileA.toPath()), StandardCharsets.UTF_8);
+        String storedB = new String(Files.readAllBytes(fileB.toPath()), StandardCharsets.UTF_8);
+        assertNotEquals(storedA, storedB);
+
+        // Both must still verify the same password despite different salts.
+        assertTrue(new PasswordManager(fileA.getAbsolutePath()).verifyPassword("samepass"));
+        assertTrue(new PasswordManager(fileB.getAbsolutePath()).verifyPassword("samepass"));
+    }
+
+    @Test
+    void legacyHashVerifiesAndIsUpgraded(@TempDir Path tempDir) throws Exception {
+        File file = tempDir.resolve("password.json").toFile();
+        writeLegacyHash(file, "legacypw");
+
+        PasswordManager mgr = new PasswordManager(file.getAbsolutePath());
+        assertTrue(mgr.isPasswordSet());
+        // Wrong password must not verify against the legacy hash.
+        assertFalse(mgr.verifyPassword("nope"));
+        // Correct password verifies and triggers transparent upgrade.
+        assertTrue(mgr.verifyPassword("legacypw"));
+
+        String upgraded = new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8);
+        assertFalse(upgraded.contains("passwordHash"));
+        assertTrue(upgraded.contains("salt"));
+
+        // After upgrade the password still verifies via the salted scheme.
+        assertTrue(new PasswordManager(file.getAbsolutePath()).verifyPassword("legacypw"));
+    }
+
+    private static void writeLegacyHash(File file, String password) throws Exception {
+        JSONObject json = new JSONObject();
+        json.put("passwordHash", sha256Hex(password));
+        try (PrintWriter writer = new PrintWriter(file, "UTF-8")) {
+            writer.write(json.toString(4));
+        }
+    }
+
+    private static String sha256Hex(String password) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+        StringBuilder hexString = new StringBuilder();
+        for (byte b : hash) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) hexString.append('0');
+            hexString.append(hex);
+        }
+        return hexString.toString();
     }
 }


### PR DESCRIPTION
## Summary

Hardens the app unlock-password hashing in `PasswordManager`, addressing #9.

Previously the unlock password was hashed with a single, **unsalted SHA-256** pass and the bare hex digest was stored in `password.json`. SHA-256 is a fast general-purpose hash, so with no salt and no work factor identical passwords produced identical digests and the stored hash was cheap to brute-force / rainbow-table if the file ever leaked.

## Changes

- **Salted, slow KDF**: derive the hash with `PBKDF2WithHmacSHA256` (210,000 iterations, a per-password 16-byte `SecureRandom` salt, 256-bit output). No new dependency — uses the JDK's `javax.crypto`.
- **New on-disk format**: store `{ algo, salt, iterations, hash }` (salt and hash Base64-encoded) instead of a bare `passwordHash`.
- **Constant-time comparison**: verification uses `MessageDigest.isEqual`.
- **Backward-compatible migration**: a legacy bare-hex `passwordHash` is still accepted — it verifies once against the old SHA-256 scheme, then the password is transparently re-hashed and rewritten in the salted format on that successful unlock, so existing users are not locked out.

## Tests

Updated `PasswordManagerTest` to cover the new scheme:
- stored format is salted KDF and never the bare SHA-256 digest,
- identical passwords produce different stored hashes (salting works),
- a legacy hash verifies, rejects a wrong password, and is upgraded in place.

Full suite green locally: `Tests run: 54, Failures: 0, Errors: 0`.

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vk5vkNaAxBNiehm8CEa6Qp

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vk5vkNaAxBNiehm8CEa6Qp)_